### PR TITLE
arm: add support for BoardConfig to append CFLAG

### DIFF
--- a/core/combo/TARGET_linux-arm.mk
+++ b/core/combo/TARGET_linux-arm.mk
@@ -117,7 +117,7 @@ TARGET_GLOBAL_CFLAGS += \
 			-Wstrict-aliasing=2 \
 			-fgcse-after-reload \
 			-frerun-cse-after-loop \
-			-frename-registers
+			-frename-registers $(BOARD_GLOBAL_CFLAGS)
 
 # arter97
 TARGET_GLOBAL_CFLAGS += \


### PR DESCRIPTION
Defining BOARD_GLOBAL_CFLAGS from BoardConfig will add a global CFLAG to be used with the entire ROM compilation

Signed-off-by: arter97 qkrwngud825@gmail.com
