### PR TITLE
build: Unset JAVA_TOOL_OPTIONS to read java version

### DIFF
--- a/core/Makefile
+++ b/core/Makefile
@@ -904,6 +904,9 @@ else
         build/target/product/security/cm-devkey
 endif
 
+# ArchiDroid
+include $(BUILD_SYSTEM)/archidroid.mk
+
 # Generate a file containing the keys that will be read by the
 # recovery binary.
 RECOVERY_INSTALL_OTA_KEYS := \
@@ -964,7 +967,9 @@ $(INSTALLED_RECOVERYIMAGE_TARGET): $(MKBOOTIMG) $(recovery_ramdisk) \
 ifeq (true,$(PRODUCTS.$(INTERNAL_PRODUCT).PRODUCT_SUPPORTS_VERITY))
 	$(BOOT_SIGNER) /recovery $@ $(PRODUCTS.$(INTERNAL_PRODUCT).PRODUCT_VERITY_SIGNING_KEY).pk8 $(PRODUCTS.$(INTERNAL_PRODUCT).PRODUCT_VERITY_SIGNING_KEY).x509.pem $@
 endif
+ifneq ($(ARCHIDROID_IGNORE_RECOVERY_SIZE),true)
 	$(hide) $(call assert-max-image-size,$@,$(BOARD_RECOVERYIMAGE_PARTITION_SIZE))
+endif
 	@echo -e ${CL_CYN}"Made recovery image: $@"${CL_RST}
 
 endif # BOARD_CUSTOM_BOOTIMG_MK

--- a/core/archidroid.mk
+++ b/core/archidroid.mk
@@ -1,0 +1,121 @@
+#     _             _     _ ____            _     _
+#    / \   _ __ ___| |__ (_)  _ \ _ __ ___ (_) __| |
+#   / _ \ | '__/ __| '_ \| | | | | '__/ _ \| |/ _` |
+#  / ___ \| | | (__| | | | | |_| | | | (_) | | (_| |
+# /_/   \_\_|  \___|_| |_|_|____/|_|  \___/|_|\__,_|
+#
+# Copyright 2015 Łukasz "JustArchi" Domeradzki
+# Contact: JustArchi@JustArchi.net
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# GCC
+
+# General optimization level of target ARM compiled with GCC. Default: -O2
+ARCHIDROID_GCC_CFLAGS_ARM := -O3
+
+# General optimization level of target THUMB compiled with GCC. Default: -Os
+ARCHIDROID_GCC_CFLAGS_THUMB := -O3
+
+# Additional flags passed to all C targets compiled with GCC
+ARCHIDROID_GCC_CFLAGS := -O3 -fgcse-las -fgcse-sm -fipa-pta -fivopts -fomit-frame-pointer -frename-registers -fsection-anchors -ftracer -ftree-loop-im -ftree-loop-ivcanon -funsafe-loop-optimizations -funswitch-loops -fweb -Wno-error=array-bounds -Wno-error=clobbered -Wno-error=maybe-uninitialized -Wno-error=strict-overflow
+
+############################
+### EXPERIMENTAL SECTION ###
+############################
+
+# The following flags were tested, and found to be causing compilation issues / other problems
+
+# ARCHIDROID_GCC_CFLAGS += -fmodulo-sched -fmodulo-sched-allow-regmoves
+# Disabled because of:
+# {standard input}: Assembler messages:
+# {standard input}:571: Error: symbol `.LPIC38' is already defined
+# external/chromium_org/third_party/zlib/crc32.c
+
+# If your arm-linux-androideabi includes support for graphite optimization flags (CLooG), enable additional flags
+
+# ARCHIDROID_GCC_CFLAGS += -fgraphite
+# Disabled because of internal compiler error:
+# 0x5ceefc gsi_for_stmt(gimple_statement_d*)
+# 0xa8788e insert_out_of_ssa_copy
+# 0xa87ede rewrite_phi_out_of_ssa
+# 0xa8e233 rewrite_reductions_out_of_ssa
+# 0xa8e233 build_poly_scop(scop*)
+# 0xa79686 graphite_transform_loops()
+# 0x7dca56 graphite_transforms
+
+############################
+### EXPERIMENTAL SECTION ###
+############################
+
+# Flags passed to all C++ targets compiled with GCC
+ARCHIDROID_GCC_CPPFLAGS := $(ARCHIDROID_GCC_CFLAGS)
+
+# Flags passed to linker (ld) of all C and C++ targets compiled with GCC
+ARCHIDROID_GCC_LDFLAGS := -Wl,--sort-common
+
+
+# CLANG
+
+# Flags passed to all C targets compiled with CLANG
+ARCHIDROID_CLANG_CFLAGS := -O3 -Qunused-arguments -Wno-unknown-warning-option
+
+# Flags passed to all C++ targets compiled with CLANG
+ARCHIDROID_CLANG_CPPFLAGS := $(ARCHIDROID_CLANG_CFLAGS)
+
+# Flags passed to linker (ld) of all C and C++ targets compiled with CLANG
+ARCHIDROID_CLANG_LDFLAGS := -Wl,--sort-common
+
+# Flags that are used by GCC, but are unknown to CLANG. If you get "argument unused during compilation" error, add the flag here
+ARCHIDROID_CLANG_UNKNOWN_FLAGS := \
+  -mvectorize-with-neon-double \
+  -mvectorize-with-neon-quad \
+  -fgcse-after-reload \
+  -fgcse-las \
+  -fgcse-sm \
+  -fgraphite \
+  -fgraphite-identity \
+  -fipa-pta \
+  -floop-block \
+  -floop-interchange \
+  -floop-nest-optimize \
+  -floop-parallelize-all \
+  -ftree-parallelize-loops=2 \
+  -ftree-parallelize-loops=4 \
+  -ftree-parallelize-loops=8 \
+  -ftree-parallelize-loops=16 \
+  -floop-strip-mine \
+  -fmodulo-sched \
+  -fmodulo-sched-allow-regmoves \
+  -frerun-cse-after-loop \
+  -frename-registers \
+  -fsection-anchors \
+  -ftree-loop-im \
+  -ftree-loop-ivcanon \
+  -funsafe-loop-optimizations \
+  -fweb
+
+
+# General
+
+# Most of the flags are increasing code size of the output binaries, especially O3 instead of Os for target THUMB
+# This may become problematic for small blocks, especially for boot or recovery blocks (ramdisks)
+# If you don't care about the size of recovery.img, e.g. you have no use of it, and you want to silence the
+# error "image too large" for recovery.img, use this definition
+#
+# NOTICE: It's better to use device-based flag TARGET_NO_RECOVERY instead, but some devices may have
+# boot + recovery combo (e.g. Sony Xperias), and we must build recovery for them, so we can't set TARGET_NO_RECOVERY globally
+# Therefore, this seems like a safe approach (will only ignore check on recovery.img, without doing anything else)
+# However, if you use compiled recovery.img for your device, please disable this flag (comment or set to false), and lower
+# optimization levels instead
+ARCHIDROID_IGNORE_RECOVERY_SIZE := true

--- a/core/clang/config.mk
+++ b/core/clang/config.mk
@@ -35,6 +35,12 @@ CLANG_CONFIG_EXTRA_CFLAGS :=
 CLANG_CONFIG_EXTRA_CPPFLAGS :=
 CLANG_CONFIG_EXTRA_LDFLAGS :=
 
+# ArchiDroid
+include $(BUILD_SYSTEM)/archidroid.mk
+CLANG_CONFIG_EXTRA_CFLAGS += $(ARCHIDROID_CLANG_CFLAGS)
+CLANG_CONFIG_EXTRA_CPPFLAGS += $(ARCHIDROID_CLANG_CPPFLAGS)
+CLANG_CONFIG_EXTRA_LDFLAGS += $(ARCHIDROID_CLANG_LDFLAGS)
+
 CLANG_CONFIG_EXTRA_CFLAGS += \
   -w -O3 -Qunused-arguments -Wno-unknown-warning-option -D__compiler_offsetof=__builtin_offsetof
 
@@ -48,6 +54,7 @@ CLANG_CONFIG_EXTRA_CFLAGS += \
   -Wno-unused-command-line-argument
 
 CLANG_CONFIG_UNKNOWN_CFLAGS := \
+  $(ARCHIDROID_CLANG_UNKNOWN_FLAGS) \
   -funswitch-loops \
   -fno-tree-sra \
   -finline-limit=64 \

--- a/core/combo/HOST_linux-x86.mk
+++ b/core/combo/HOST_linux-x86.mk
@@ -31,7 +31,7 @@ endif # $($(combo_2nd_arch_prefix)HOST_TOOLCHAIN_PREFIX)gcc exists
 $(combo_2nd_arch_prefix)HOST_TOOLCHAIN_FOR_CLANG := prebuilts/gcc/linux-x86/host/x86_64-linux-glibc2.11-4.6/
 
 # We expect SSE3 floating point math.
-$(combo_2nd_arch_prefix)HOST_GLOBAL_CFLAGS += -mstackrealign -msse3 -mfpmath=sse -m32 -Wa,--noexecstack -march=prescott
+$(combo_2nd_arch_prefix)HOST_GLOBAL_CFLAGS += -mstackrealign -msse3 -mfpmath=sse -m32 -Wa,--noexecstack -march=native
 $(combo_2nd_arch_prefix)HOST_GLOBAL_LDFLAGS += -m32 -Wl,-z,noexecstack
 
 ifneq ($(strip $(BUILD_HOST_static)),)

--- a/core/combo/HOST_linux-x86_64.mk
+++ b/core/combo/HOST_linux-x86_64.mk
@@ -30,7 +30,7 @@ endif # $(HOST_TOOLCHAIN_PREFIX)gcc exists
 # gcc location for clang; to be updated when clang is updated
 HOST_TOOLCHAIN_FOR_CLANG := prebuilts/gcc/linux-x86/host/x86_64-linux-glibc2.11-4.6/
 
-HOST_GLOBAL_CFLAGS += -m64 -Wa,--noexecstack
+HOST_GLOBAL_CFLAGS += -m64 -march=native -Wa,--noexecstack
 HOST_GLOBAL_LDFLAGS += -m64 -Wl,-z,noexecstack
 
 ifneq ($(strip $(BUILD_HOST_static)),)

--- a/core/combo/TARGET_linux-arm.mk
+++ b/core/combo/TARGET_linux-arm.mk
@@ -67,7 +67,10 @@ $(combo_2nd_arch_prefix)TARGET_STRIP := $($(combo_2nd_arch_prefix)TARGET_TOOLS_P
 
 $(combo_2nd_arch_prefix)TARGET_NO_UNDEFINED_LDFLAGS := -Wl,--no-undefined
 
-$(combo_2nd_arch_prefix)TARGET_arm_CFLAGS :=    -O3 \
+# ArchiDroid
+include $(BUILD_SYSTEM)/archidroid.mk
+
+$(combo_2nd_arch_prefix)TARGET_arm_CFLAGS :=    $(ARCHIDROID_GCC_CFLAGS_ARM) \
                         -fomit-frame-pointer \
                         -fstrict-aliasing    \
                         -funswitch-loops
@@ -75,8 +78,13 @@ $(combo_2nd_arch_prefix)TARGET_arm_CFLAGS :=    -O3 \
 # Modules can choose to compile some source as thumb.
 $(combo_2nd_arch_prefix)TARGET_thumb_CFLAGS :=  -mthumb \
                         -O3 \
+                        $(ARCHIDROID_GCC_CFLAGS_THUMB) \
                         -fomit-frame-pointer \
                         -fno-strict-aliasing
+
+$(combo_2nd_arch_prefix)TARGET_GLOBAL_CFLAGS += $(ARCHIDROID_GCC_CFLAGS)
+$(combo_2nd_arch_prefix)TARGET_GLOBAL_CPPFLAGS += $(ARCHIDROID_GCC_CPPFLAGS)
+$(combo_2nd_arch_prefix)TARGET_GLOBAL_LDFLAGS += $(ARCHIDROID_GCC_LDFLAGS)
 
 # Set FORCE_ARM_DEBUGGING to "true" in your buildspec.mk
 # or in your environment to force a full arm build, even for
@@ -127,6 +135,15 @@ $(combo_2nd_arch_prefix)TARGET_GLOBAL_CFLAGS += \
 			-funroll-loops \
 			-mvectorize-with-neon-quad
 
+# The "-Wunused-but-set-variable" option often breaks projects that enable
+# "-Wall -Werror" due to a commom idiom "ALOGV(mesg)" where ALOGV is turned
+# into no-op in some builds while mesg is defined earlier. So we explicitly
+# disable "-Wunused-but-set-variable" here.
+ifneq ($(filter 4.6 4.6.% 4.7 4.7.% 4.8 4.8.% 4.9 4.9.%, $($(combo_2nd_arch_prefix)TARGET_GCC_VERSION)),)
+$(combo_2nd_arch_prefix)TARGET_GLOBAL_CFLAGS += -fno-builtin-sin \
+			-fno-strict-volatile-bitfields
+endif
+
 # This is to avoid the dreaded warning compiler message:
 #   note: the mangling of 'va_list' has changed in GCC 4.4
 #
@@ -153,6 +170,14 @@ $(combo_2nd_arch_prefix)TARGET_GLOBAL_LDFLAGS += $(BOARD_GLOBAL_LDFLAGS)
 $(combo_2nd_arch_prefix)TARGET_GLOBAL_CFLAGS += -mthumb-interwork
 
 $(combo_2nd_arch_prefix)TARGET_GLOBAL_CPPFLAGS += -fvisibility-inlines-hidden
+
+# More flags/options can be added here
+$(combo_2nd_arch_prefix)TARGET_RELEASE_CFLAGS := \
+			-DNDEBUG \
+			-Wstrict-aliasing=2 \
+			-fgcse-after-reload \
+			-frerun-cse-after-loop \
+			-frename-registers
 
 libc_root := bionic/libc
 libm_root := bionic/libm

--- a/core/main.mk
+++ b/core/main.mk
@@ -143,8 +143,8 @@ $(warning ************************************************************)
 $(error Directory names containing spaces not supported)
 endif
 
-java_version_str := $(shell unset _JAVA_OPTIONS && java -version 2>&1)
-javac_version_str := $(shell unset _JAVA_OPTIONS && javac -version 2>&1)
+java_version_str := $(shell unset _JAVA_OPTIONS && unset JAVA_TOOL_OPTIONS && java -version 2>&1)
+javac_version_str := $(shell unset _JAVA_OPTIONS && unset JAVA_TOOL_OPTIONS && javac -version 2>&1)
 
 # Check for the correct version of java, should be 1.7 by
 # default, and 1.6 if LEGACY_USE_JAVA6 is set.

--- a/core/main.mk
+++ b/core/main.mk
@@ -151,13 +151,13 @@ javac_version_str := $(shell unset _JAVA_OPTIONS && unset JAVA_TOOL_OPTIONS && j
 ifeq ($(LEGACY_USE_JAVA6),)
 required_version := "1.7.x/1.8.x"
 required_javac_version := "1.7/1.8"
-java_version := $(shell echo '$(java_version_str)' | grep -E '^(java|openjdk) .*[ "]1\.[78][\.*_ "$$]')
-javac_version := $(shell echo '$(javac_version_str)' | grep '[ "]1\.[78][\.*_ "$$]')
+java_version := $(shell echo '$(java_version_str)' | grep -E '^(java|openjdk) .*[ "]1\.[78][\. "$$]')
+javac_version := $(shell echo '$(javac_version_str)' | grep '[ "]1\.[78][\. "$$]')
 else # if LEGACY_USE_JAVA6
 required_version := "1.6.x"
 required_javac_version := "1.6"
-java_version := $(shell echo '$(java_version_str)' | grep '^java .*[ "]1\.6[\.*_ "$$]')
-javac_version := $(shell echo '$(javac_version_str)' | grep '[ "]1\.6[\.*_ "$$]')
+java_version := $(shell echo '$(java_version_str)' | grep '^java .*[ "]1\.6[\. "$$]')
+javac_version := $(shell echo '$(javac_version_str)' | grep '[ "]1\.6[\. "$$]')
 endif # if LEGACY_USE_JAVA6
 
 ifeq ($(strip $(java_version)),)

--- a/core/main.mk
+++ b/core/main.mk
@@ -151,13 +151,13 @@ javac_version_str := $(shell unset _JAVA_OPTIONS && javac -version 2>&1)
 ifeq ($(LEGACY_USE_JAVA6),)
 required_version := "1.7.x/1.8.x"
 required_javac_version := "1.7/1.8"
-java_version := $(shell echo '$(java_version_str)' | grep -E '^(java|openjdk) .*[ "]1\.[78][\. "$$]')
-javac_version := $(shell echo '$(javac_version_str)' | grep '[ "]1\.[78][\. "$$]')
+java_version := $(shell echo '$(java_version_str)' | grep -E '^(java|openjdk) .*[ "]1\.[78][\.*_ "$$]')
+javac_version := $(shell echo '$(javac_version_str)' | grep '[ "]1\.[78][\.*_ "$$]')
 else # if LEGACY_USE_JAVA6
 required_version := "1.6.x"
 required_javac_version := "1.6"
-java_version := $(shell echo '$(java_version_str)' | grep '^java .*[ "]1\.6[\. "$$]')
-javac_version := $(shell echo '$(javac_version_str)' | grep '[ "]1\.6[\. "$$]')
+java_version := $(shell echo '$(java_version_str)' | grep '^java .*[ "]1\.6[\.*_ "$$]')
+javac_version := $(shell echo '$(javac_version_str)' | grep '[ "]1\.6[\.*_ "$$]')
 endif # if LEGACY_USE_JAVA6
 
 ifeq ($(strip $(java_version)),)


### PR DESCRIPTION
If env variable JAVA_TOOL_OPTIONS is set, it breaks the expected java
version output. Exp:

 Picked up JAVA_TOOL_OPTIONS: -javaagent:/usr/share/java/jayatanaag.jar
 java version "1.7.0_79"
 OpenJDK Runtime Environment (IcedTea 2.5.5) (7u79-2.5.5-0ubuntu1)
 OpenJDK 64-Bit Server VM (build 24.79-b02, mixed mode)

Unset JAVA_TOOL_OPTIONS for the purposes of reading java and javac
versions. This was encountered on an Ubuntu 15.04 system.

Change-Id: I288faaa18f8589e29cd436fc9568c1a879618c65
...

This commit is needed for build on Ubuntu 15.04 (Vivid Vervet)
