### PR TITLE
tools:ota:don't mount system partition with recovery mount options

### DIFF
--- a/tools/releasetools/ota_from_target_files
+++ b/tools/releasetools/ota_from_target_files
@@ -633,7 +633,7 @@ def WriteFullOTAPackage(input_zip, output_zip):
     system_diff.WriteScript(script, output_zip)
   else:
     script.FormatPartition("/system")
-    script.Mount("/system", recovery_mount_options)
+    script.Mount("/system")
     if OPTIONS.recovery and not has_recovery_patch:
       script.UnpackPackageDir("recovery", "/system")
     script.UnpackPackageDir("system", "/system")


### PR DESCRIPTION
Because we are building without block based, the script generates something like:

mount("ext4", "EMMC", "/dev/block/platform/dw_mmc.0/by-name/system", "/system", "max_batch_time=0,commit=1,data=ordered,barrier=1,errors=panic,nodelalloc");

Those options are not supported by f2fs, thus mounting throws an error.
